### PR TITLE
feat: implement ability to open as secondary db

### DIFF
--- a/rocksdb/db.pxd
+++ b/rocksdb/db.pxd
@@ -181,6 +181,7 @@ cdef extern from "rocksdb/db.h" namespace "rocksdb":
         void GetLiveFilesMetaData(vector[LiveFileMetaData]*) nogil except+
         void GetColumnFamilyMetaData(ColumnFamilyHandle*, ColumnFamilyMetaData*) nogil except+
         ColumnFamilyHandle* DefaultColumnFamily()
+        Status TryCatchUpWithPrimary() nogil except+
 
 
     cdef Status DB_Open "rocksdb::DB::Open"(
@@ -190,6 +191,20 @@ cdef extern from "rocksdb/db.h" namespace "rocksdb":
 
     cdef Status DB_Open_ColumnFamilies "rocksdb::DB::Open"(
         const options.Options&,
+        const string&,
+        const vector[ColumnFamilyDescriptor]&,
+        vector[ColumnFamilyHandle*]*,
+        DB**) nogil except+
+
+    cdef Status DB_OpenAsSecondary "rocksdb::DB::OpenAsSecondary"(
+        const options.Options&,
+        const string&,
+        const string&,
+        DB**) nogil except+
+
+    cdef Status DB_OpenAsSecondary_ColumnFamilies "rocksdb::DB::OpenAsSecondary"(
+        const options.Options&,
+        const string&,
         const string&,
         const vector[ColumnFamilyDescriptor]&,
         vector[ColumnFamilyHandle*]*,


### PR DESCRIPTION
### Motivation

Add support for the Open as Secondary feature.

### Acceptance Criteria

- Add optional `secondary_path` arg to DB init, to open it as a secondary DB.
- Add `try_catch_up_with_primary()` method.