### PR TITLE
fix: remove obsolete option

### DIFF
--- a/docs/api/options.rst
+++ b/docs/api/options.rst
@@ -846,7 +846,6 @@ CompressionTypes
     .. py:attribute:: lz4hc_compression
     .. py:attribute:: xpress_compression
     .. py:attribute:: zstd_compression
-    .. py:attribute:: zstdnotfinal_compression
     .. py:attribute:: disable_compression
 
 

--- a/rocksdb/_rocksdb.pyx
+++ b/rocksdb/_rocksdb.pyx
@@ -600,7 +600,6 @@ cdef class CompressionType(object):
     lz4hc_compression = u'lz4hc_compression'
     xpress_compression = u'xpress_compression'
     zstd_compression = u'zstd_compression'
-    zstdnotfinal_compression = u'zstdnotfinal_compression'
     disable_compression = u'disable_compression'
 
 cdef class CompactionPri(object):
@@ -827,8 +826,6 @@ cdef class ColumnFamilyOptions(object):
                 return CompressionType.xpress_compression
             elif self.copts.compression == options.kZSTD:
                 return CompressionType.zstd_compression
-            elif self.copts.compression == options.kZSTDNotFinalCompression:
-                return CompressionType.zstdnotfinal_compression
             elif self.copts.compression == options.kDisableCompressionOption:
                 return CompressionType.disable_compression
             else:
@@ -849,8 +846,6 @@ cdef class ColumnFamilyOptions(object):
                 self.copts.compression = options.kLZ4HCCompression
             elif value == CompressionType.zstd_compression:
                 self.copts.compression = options.kZSTD
-            elif value == CompressionType.zstdnotfinal_compression:
-                self.copts.compression = options.kZSTDNotFinalCompression
             elif value == CompressionType.disable_compression:
                 self.copts.compression = options.kDisableCompressionOption
             else:

--- a/rocksdb/options.pxd
+++ b/rocksdb/options.pxd
@@ -42,7 +42,6 @@ cdef extern from "rocksdb/options.h" namespace "rocksdb":
         kLZ4HCCompression
         kXpressCompression
         kZSTD
-        kZSTDNotFinalCompression
         kDisableCompressionOption
 
     ctypedef enum ReadTier:


### PR DESCRIPTION
### Motivation

RocksBD build on macOS is currently failing on hathor-core CI, because the bindings must be updated.

### Acceptance Criteria

- Remove deprecated `kZSTDNotFinalCompression` option ([changelog](https://github.com/facebook/rocksdb/blob/17ac19f2c448856f2cfca2d85500f8b0b4af0bdc/HISTORY.md?plain=1#L16)). 