### PR TITLE
chore(ci): update macos

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rocksdb-version: ['v6.29.5', 'v7.10.2', 'v8.11.4', 'v9.10.0']
+        rocksdb-version: ['v10.0.1', 'v10.7.5']
 
     steps:
       - uses: actions/cache@v4
@@ -68,8 +68,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
-        rocksdb-version: ['v6.29.5', 'v7.10.2', 'v8.11.4', 'v9.10.0']
+        python-version: ['3.11', '3.12', '3.13']
+        rocksdb-version: ['v10.0.1', 'v10.7.5']
 
     steps:
       - uses: actions/checkout@v4
@@ -113,9 +113,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - { arch: 'Intel', runner: 'macos-13' }
-          - { arch: 'Arm', runner: 'macos-latest' }
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+          - macos-15
+        python-version: ['3.11', '3.12', '3.13']
 
     steps:
       - uses: actions/checkout@v4
@@ -149,7 +148,7 @@ jobs:
         os:
           - { arch: 'x64', runner: 'ubuntu-latest' }
           - { arch: 'arm', runner: 'ubuntu-24.04-arm' }
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13']
         debian-dist: [bullseye, bookworm]
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rocksdb"
-version = "0.9.3"
+version = "0.10.0"
 description = "Python bindings for RocksDB"
 readme = "README.md"
 authors = [
@@ -13,7 +13,7 @@ maintainers = [
     { name = "Jan Segre", email = "jan@hathor.network" },
 ]
 #url = "https://github.com/HathorNetwork/python-rocksdb"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 #license = "BSD-3-Clause"
 license = {file = "LICENSE"}
 keywords = ["rocksdb", "bindings"]
@@ -31,7 +31,6 @@ classifiers = [
 
   # Specify the Python versions you support here.
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
 ]

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def get_brew_prefix(package):
 include_dirs = []
 library_dirs = []
 extra_compile_args = [
-    "-std=c++17",
+    "-std=c++20",
     "-O2",
     "-fno-strict-aliasing",
     "-fno-rtti",
@@ -22,7 +22,7 @@ extra_compile_args = [
 
 if platform.system() == "Darwin":
     extra_compile_args.extend([
-        "-mmacosx-version-min=10.7",
+        "-mmacosx-version-min=11.0",
         "-stdlib=libc++",
         "-Wno-unreachable-code",
     ])


### PR DESCRIPTION
### Motivation

The `macos-13` GitHub runners that we use [are being deprecated](https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/#macos-13-is-closing-down), so we must update them.

### Acceptance Criteria

- Update the CI rocksdb version matrix from `['v6.29.5', 'v7.10.2', 'v8.11.4', 'v9.10.0']` to `['v10.0.1', 'v10.7.5']`. The old matrix was too outdated, we haven't supported these versions for a while. The two I kept are the lowest one I'm sure works and the latest one.
- Remove support for Python 3.10 on the CI.
- Remove support for `macos-13` and add `macos-15` on the CI.
- Bump version to `0.10.0`.
- Update build to use C++20 and bump min macos version to `11.0`. Those were required to make the build work on CI.