### PR TITLE
fix: CI/CD not running for MacOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,7 +113,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-15
+          - { arch: 'Arm', runner: 'macos-15' }
         python-version: ['3.11', '3.12', '3.13']
 
     steps:


### PR DESCRIPTION
### Acceptance Criteria

Fix this error in Github Actions:

```
Error when evaluating 'runs-on' for job 'test-macos'. .github/workflows/test.yml (Line: 111, Col: 14): Unexpected value ''
```