### PR TITLE
fix: support building against rocksdb-11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rocksdb"
-version = "0.10.0"
+version = "0.10.1"
 description = "Python bindings for RocksDB"
 readme = "README.md"
 authors = [

--- a/rocksdb/_rocksdb.pyx
+++ b/rocksdb/_rocksdb.pyx
@@ -1568,6 +1568,7 @@ cdef class DB(object):
             del self.cf_options[:]
             with nogil:
                 st = self.db.Close()
+                db.DB_Destroy(self.db)
                 self.db = NULL
             if self.opts is not None:
                 self.opts.in_use = False

--- a/rocksdb/cpp/db_helpers.hpp
+++ b/rocksdb/cpp/db_helpers.hpp
@@ -1,0 +1,186 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rocksdb/version.h"
+#include "rocksdb/db.h"
+
+#ifndef ROCKSDB_MAKE_VERSION_INT
+#define ROCKSDB_MAKE_VERSION_INT(a, b, c) ((a) * 1000000 + (b) * 1000 + (c))
+#endif
+#ifndef ROCKSDB_VERSION_INT
+#define ROCKSDB_VERSION_INT \
+    ROCKSDB_MAKE_VERSION_INT(ROCKSDB_MAJOR, ROCKSDB_MINOR, ROCKSDB_PATCH)
+#endif
+#ifndef ROCKSDB_VERSION_GE
+#define ROCKSDB_VERSION_GE(a, b, c) \
+    (ROCKSDB_VERSION_INT >= ROCKSDB_MAKE_VERSION_INT(a, b, c))
+#endif
+
+namespace py_rocks {
+
+inline rocksdb::Status DBOpen(
+        const rocksdb::Options& options,
+        const std::string& name,
+        rocksdb::DB** dbptr) {
+    *dbptr = nullptr;
+#if ROCKSDB_VERSION_GE(10, 0, 0)
+    std::unique_ptr<rocksdb::DB> db;
+    auto status = rocksdb::DB::Open(options, name, &db);
+    if (status.ok()) {
+        *dbptr = db.release();
+    }
+    return status;
+#else
+    return rocksdb::DB::Open(options, name, dbptr);
+#endif
+}
+
+inline rocksdb::Status DBOpenColumnFamilies(
+        const rocksdb::Options& options,
+        const std::string& name,
+        const std::vector<rocksdb::ColumnFamilyDescriptor>& column_families,
+        std::vector<rocksdb::ColumnFamilyHandle*>* handles,
+        rocksdb::DB** dbptr) {
+    *dbptr = nullptr;
+#if ROCKSDB_VERSION_GE(10, 0, 0)
+    std::unique_ptr<rocksdb::DB> db;
+    auto status = rocksdb::DB::Open(
+            options,
+            name,
+            column_families,
+            handles,
+            &db);
+    if (status.ok()) {
+        *dbptr = db.release();
+    }
+    return status;
+#else
+    return rocksdb::DB::Open(
+            options,
+            name,
+            column_families,
+            handles,
+            dbptr);
+#endif
+}
+
+inline rocksdb::Status DBOpenAsSecondary(
+        const rocksdb::Options& options,
+        const std::string& name,
+        const std::string& secondary_path,
+        rocksdb::DB** dbptr) {
+    *dbptr = nullptr;
+#if ROCKSDB_VERSION_GE(10, 0, 0)
+    std::unique_ptr<rocksdb::DB> db;
+    auto status = rocksdb::DB::OpenAsSecondary(
+            options,
+            name,
+            secondary_path,
+            &db);
+    if (status.ok()) {
+        *dbptr = db.release();
+    }
+    return status;
+#else
+    return rocksdb::DB::OpenAsSecondary(options, name, secondary_path, dbptr);
+#endif
+}
+
+inline rocksdb::Status DBOpenAsSecondaryColumnFamilies(
+        const rocksdb::Options& options,
+        const std::string& name,
+        const std::string& secondary_path,
+        const std::vector<rocksdb::ColumnFamilyDescriptor>& column_families,
+        std::vector<rocksdb::ColumnFamilyHandle*>* handles,
+        rocksdb::DB** dbptr) {
+    *dbptr = nullptr;
+#if ROCKSDB_VERSION_GE(10, 0, 0)
+    std::unique_ptr<rocksdb::DB> db;
+    auto status = rocksdb::DB::OpenAsSecondary(
+            options,
+            name,
+            secondary_path,
+            column_families,
+            handles,
+            &db);
+    if (status.ok()) {
+        *dbptr = db.release();
+    }
+    return status;
+#else
+    return rocksdb::DB::OpenAsSecondary(
+            options,
+            name,
+            secondary_path,
+            column_families,
+            handles,
+            dbptr);
+#endif
+}
+
+inline rocksdb::Status DBOpenForReadOnly(
+        const rocksdb::Options& options,
+        const std::string& name,
+        rocksdb::DB** dbptr,
+        bool error_if_wal_file_exists) {
+    *dbptr = nullptr;
+#if ROCKSDB_VERSION_GE(10, 0, 0)
+    std::unique_ptr<rocksdb::DB> db;
+    auto status = rocksdb::DB::OpenForReadOnly(
+            options,
+            name,
+            &db,
+            error_if_wal_file_exists);
+    if (status.ok()) {
+        *dbptr = db.release();
+    }
+    return status;
+#else
+    return rocksdb::DB::OpenForReadOnly(
+            options,
+            name,
+            dbptr,
+            error_if_wal_file_exists);
+#endif
+}
+
+inline rocksdb::Status DBOpenForReadOnlyColumnFamilies(
+        const rocksdb::Options& options,
+        const std::string& name,
+        const std::vector<rocksdb::ColumnFamilyDescriptor>& column_families,
+        std::vector<rocksdb::ColumnFamilyHandle*>* handles,
+        rocksdb::DB** dbptr,
+        bool error_if_wal_file_exists) {
+    *dbptr = nullptr;
+#if ROCKSDB_VERSION_GE(10, 0, 0)
+    std::unique_ptr<rocksdb::DB> db;
+    auto status = rocksdb::DB::OpenForReadOnly(
+            options,
+            name,
+            column_families,
+            handles,
+            &db,
+            error_if_wal_file_exists);
+    if (status.ok()) {
+        *dbptr = db.release();
+    }
+    return status;
+#else
+    return rocksdb::DB::OpenForReadOnly(
+            options,
+            name,
+            column_families,
+            handles,
+            dbptr,
+            error_if_wal_file_exists);
+#endif
+}
+
+inline void DBDestroy(rocksdb::DB* db) {
+    delete db;
+}
+
+}  // namespace py_rocks

--- a/rocksdb/db.pxd
+++ b/rocksdb/db.pxd
@@ -185,25 +185,26 @@ cdef extern from "rocksdb/db.h" namespace "rocksdb":
         Status TryCatchUpWithPrimary() nogil except+
 
 
-    cdef Status DB_Open "rocksdb::DB::Open"(
+cdef extern from "cpp/db_helpers.hpp" namespace "py_rocks":
+    cdef Status DB_Open "py_rocks::DBOpen"(
         const options.Options&,
         const string&,
         DB**) except+ nogil
 
-    cdef Status DB_Open_ColumnFamilies "rocksdb::DB::Open"(
+    cdef Status DB_Open_ColumnFamilies "py_rocks::DBOpenColumnFamilies"(
         const options.Options&,
         const string&,
         const vector[ColumnFamilyDescriptor]&,
         vector[ColumnFamilyHandle*]*,
         DB**) except+ nogil
 
-    cdef Status DB_OpenAsSecondary "rocksdb::DB::OpenAsSecondary"(
+    cdef Status DB_OpenAsSecondary "py_rocks::DBOpenAsSecondary"(
         const options.Options&,
         const string&,
         const string&,
         DB**) nogil except+
 
-    cdef Status DB_OpenAsSecondary_ColumnFamilies "rocksdb::DB::OpenAsSecondary"(
+    cdef Status DB_OpenAsSecondary_ColumnFamilies "py_rocks::DBOpenAsSecondaryColumnFamilies"(
         const options.Options&,
         const string&,
         const string&,
@@ -211,19 +212,23 @@ cdef extern from "rocksdb/db.h" namespace "rocksdb":
         vector[ColumnFamilyHandle*]*,
         DB**) nogil except+
 
-    cdef Status DB_OpenForReadOnly "rocksdb::DB::OpenForReadOnly"(
+    cdef Status DB_OpenForReadOnly "py_rocks::DBOpenForReadOnly"(
         const options.Options&,
         const string&,
         DB**,
         cpp_bool) except+ nogil
 
-    cdef Status DB_OpenForReadOnly_ColumnFamilies "rocksdb::DB::OpenForReadOnly"(
+    cdef Status DB_OpenForReadOnly_ColumnFamilies "py_rocks::DBOpenForReadOnlyColumnFamilies"(
         const options.Options&,
         const string&,
         const vector[ColumnFamilyDescriptor]&,
         vector[ColumnFamilyHandle*]*,
         DB**,
         cpp_bool) except+ nogil
+
+    cdef void DB_Destroy "py_rocks::DBDestroy"(DB*) except+ nogil
+
+cdef extern from "rocksdb/db.h" namespace "rocksdb":
 
     cdef Status RepairDB(const string& dbname, const options.Options&)
 


### PR DESCRIPTION
Build broke on macOS after rocksdb was updated to v11 on homebrew. This PR introduces a small shim to to fix support and restore compatibility.